### PR TITLE
Remove grayscale wireframe mode

### DIFF
--- a/Ad-Lander-2
+++ b/Ad-Lander-2
@@ -1,9 +1,8 @@
 {% comment %}
   ============================================
-  Section: Ad Lander (wireframe-first)
+  Section: Ad Lander
   File: sections/ad-lander.liquid
   Notes:
-    - Neutral grayscale wireframe styling by default (toggle: wireframe_mode)
     - Rich text fields for headers/subheads
     - Part 2 background is contained (not full-bleed)
     - Part 5 background is full-bleed; horizontal scroll carousel with JS arrows
@@ -25,8 +24,7 @@
     assign g  = section.settings.gutter | default: 24
     assign r  = section.settings.corner_radius | default: 16
     assign space = section.settings.section_space | default: 72
-    assign wireframe = section.settings.wireframe_mode
-  -%}
+    -%}
 
   <style>
     #ad-lander-{{ section.id }} {
@@ -51,7 +49,7 @@
       padding-block: var(--space-y);
     }
 
-    /* Wireframe typography */
+    /* Base typography */
     #ad-lander-{{ section.id }} .h1 { font-size: clamp(28px, 3.2vw, 40px); line-height: 1.15; margin: 0; color: var(--wire-gray-700); }
     #ad-lander-{{ section.id }} .sub { color: var(--wire-gray-500); font-size: clamp(14px, 1.6vw, 18px); line-height: 1.5; }
     #ad-lander-{{ section.id }} .rte { display: grid; gap: 8px; }
@@ -71,7 +69,6 @@
     }
     #ad-lander-{{ section.id }} .img-frame img {
       position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover;
-      {% if wireframe %} filter: grayscale(1); {% endif %}
     }
     #ad-lander-{{ section.id }} .placeholder {
       width: 100%; height: 100%; display: grid; place-items: center; color: var(--wire-gray-500); font-size: 12px;
@@ -94,7 +91,6 @@
     }
     #ad-lander-{{ section.id }} .p2-panel .bg {
       position: absolute; inset: 0; background-size: cover; background-position: center;
-      {% if wireframe %} filter: grayscale(1); {% endif %}
     }
     #ad-lander-{{ section.id }} .p2-overlay {
       position: absolute; inset: 0; pointer-events: none;
@@ -125,7 +121,6 @@
     }
     #ad-lander-{{ section.id }} .p5 .bg {
       position: absolute; inset: 0; background-size: cover; background-position: center;
-      {% if wireframe %} filter: grayscale(1); {% endif %}
     }
     #ad-lander-{{ section.id }} .p5 .overlay {
       position: absolute; inset: 0; pointer-events: none;
@@ -475,12 +470,6 @@
   "name": "Ad Lander",
   "class": "section-ad-lander",
   "settings": [
-    {
-      "type": "checkbox",
-      "id": "wireframe_mode",
-      "label": "Wireframe mode (neutral grays)",
-      "default": true
-    },
     {
       "type": "range",
       "id": "container_max",


### PR DESCRIPTION
## Summary
- remove wireframe mode toggle and grayscale filters
- show all images in full color

## Testing
- `rg -n grayscale Ad-Lander-2`

------
https://chatgpt.com/codex/tasks/task_e_68b91ceac400832db50216e5fc7037a3