### PR TITLE
Enable rich text color and alignment overrides

### DIFF
--- a/Ad-Lander-2
+++ b/Ad-Lander-2
@@ -53,6 +53,7 @@
     #ad-lander-{{ section.id }} .h1 { font-size: clamp(28px, 3.2vw, 40px); line-height: 1.15; margin: 0; color: var(--wire-gray-700); }
     #ad-lander-{{ section.id }} .sub { color: var(--wire-gray-500); font-size: clamp(14px, 1.6vw, 18px); line-height: 1.5; }
     #ad-lander-{{ section.id }} .rte { display: grid; gap: 8px; }
+    #ad-lander-{{ section.id }} .rte [data-align] { display: block; width: 100%; }
     #ad-lander-{{ section.id }} .btn {
       display: inline-flex; align-items: center; justify-content: center;
       padding: 10px 18px; border-radius: 999px; border: var(--wire-border);
@@ -431,6 +432,14 @@
   (function(){
     const root = document.getElementById('ad-lander-{{ section.id }}');
     if(!root) return;
+
+    // Apply inline color and alignment from rich text data attributes
+    root.querySelectorAll('.rte [data-color]').forEach(el => {
+      el.style.color = el.dataset.color;
+    });
+    root.querySelectorAll('.rte [data-align]').forEach(el => {
+      el.style.textAlign = el.dataset.align;
+    });
 
     // PART 5: Horizontal carousel arrows
     const track = root.querySelector('[data-track]');


### PR DESCRIPTION
## Summary
- allow block-level alignment for words marked with `data-align`
- apply custom text color via `data-color` attributes in rich text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b91f684c6c832d8f656e30e0c41b17