### PR TITLE
Remove product linking from cards and add image max-width setting

### DIFF
--- a/Ad-Lander-2
+++ b/Ad-Lander-2
@@ -404,25 +404,19 @@
         {%- if product_blocks.size > 0 -%}
           {%- for block in product_blocks limit: 3 -%}
             {%- liquid
-              assign chosen_product = block.settings.product
-              assign manual_img = block.settings.image
-              assign final_img = manual_img
-              if final_img == blank and chosen_product and chosen_product.featured_image
-                assign final_img = chosen_product.featured_image
-              endif
-
+              assign final_img = block.settings.image
               assign cta_label = block.settings.cta_label
               assign cta_url = block.settings.cta_url
-              if cta_url == blank and chosen_product
-                assign cta_url = chosen_product.url
-              endif
+              assign img_max = block.settings.image_max_width | default: 250
+              assign img_style = 'width: 100%; max-width: ' | append: img_max | append: 'px;'
             -%}
             <article class="product-item" role="listitem" {{ block.shopify_attributes }}>
               <div class="img-frame">
                 {% if final_img != blank %}
                   {{ final_img | image_url: width: 1200 | image_tag:
                     loading: 'lazy',
-                    alt: block.settings.alt | default: chosen_product.title | default: 'Product image'
+                    alt: block.settings.alt | default: 'Card image',
+                    style: img_style
                   }}
                 {% else %}
                   <div class="placeholder">9:14 image</div>
@@ -623,21 +617,21 @@
       ]
     },
     {
-      "type": "product_card",
-      "name": "Product",
-      "settings": [
-        { "type": "product", "id": "product", "label": "Product (optional)" },
-        { "type": "image_picker", "id": "image", "label": "Image override (9:14)" },
-        { "type": "text", "id": "alt", "label": "Image alt text" },
-        { "type": "richtext", "id": "subhead", "label": "Subhead" },
-        { "type": "text", "id": "cta_label", "label": "CTA label" },
-        { "type": "url", "id": "cta_url", "label": "CTA link (overrides product URL if set)" },
-        { "type": "checkbox", "id": "cta_newtab", "label": "Open CTA in new tab", "default": false }
-      ]
-    }
-  ],
-  "presets": [
-    {
+        "type": "product_card",
+        "name": "Product",
+        "settings": [
+          { "type": "image_picker", "id": "image", "label": "Image (9:14)" },
+          { "type": "range", "id": "image_max_width", "label": "Image max width (px)", "min": 50, "max": 600, "step": 10, "default": 250 },
+          { "type": "text", "id": "alt", "label": "Image alt text" },
+          { "type": "richtext", "id": "subhead", "label": "Subhead" },
+          { "type": "text", "id": "cta_label", "label": "CTA label" },
+          { "type": "url", "id": "cta_url", "label": "CTA link" },
+          { "type": "checkbox", "id": "cta_newtab", "label": "Open CTA in new tab", "default": false }
+        ]
+      }
+    ],
+    "presets": [
+      {
       "name": "Ad Lander",
       "blocks": [
         { "type": "ingredient_card" },


### PR DESCRIPTION
## Summary
- remove product picker and associated logic from product cards
- allow setting a max-width for card images

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b93738f76c832dba8150427a37d7d9