### PR TITLE
Enable customizable images for content blocks

### DIFF
--- a/Ad-Lander-2
+++ b/Ad-Lander-2
@@ -393,37 +393,24 @@
   {% endif %}
 
   <!-- =========================
-       PART 6: Product Showcase
-       Product images (blocks) with subhead + CTA under
-       Supports Product picker OR manual fields
+       PART 6: Content Blocks
+       Image, header + CTA via blocks
        ========================= -->
   {% if section.settings.show_p6 %}
   <div class="part p6" role="list" aria-label="Content items">
-    {%- assign product_blocks = section.blocks | where: 'type', 'product_card' -%}
-    {%- if product_blocks.size > 0 -%}
-      {%- for block in product_blocks -%}
+    {%- assign content_blocks = section.blocks | where: 'type', 'content_group' -%}
+    {%- if content_blocks.size > 0 -%}
+      {%- for block in content_blocks -%}
         {%- liquid
-          assign chosen_product = block.settings.product
-          assign manual_img = block.settings.image
-          assign final_img = manual_img
-          if final_img == blank and chosen_product and chosen_product.featured_image
-            assign final_img = chosen_product.featured_image
-          endif
-
-          assign alt_text = block.settings.alt
-          if alt_text == blank and chosen_product
-            assign alt_text = chosen_product.title
-          endif
-          if alt_text == blank
-            assign alt_text = 'Product image'
-          endif
+          assign img = block.settings.image
+          assign alt_text = block.settings.alt | default: 'Content image'
           assign cta_label = block.settings.cta_label
           assign cta_url = block.settings.cta_url
         -%}
-        <article class="product-card" role="listitem" {{ block.shopify_attributes }}>
-          <div class="img-frame" style="aspect-ratio: 9 / 14;">
-            {%- if final_img != blank -%}
-              {{ final_img | image_url: width: 1200 | image_tag:
+        <article class="p6-item" role="listitem" {{ block.shopify_attributes }}>
+          <div class="img-frame" style="aspect-ratio: 9 / 14; max-width: {{ block.settings.image_max_width }}px;">
+            {%- if img != blank -%}
+              {{ img | image_url: width: 1200 | image_tag:
                 loading: 'lazy',
                 alt: alt_text
               }}
@@ -432,8 +419,8 @@
             {%- endif -%}
           </div>
 
-          {%- if block.settings.subhead != blank -%}
-            <div class="sub rte">{{ block.settings.subhead }}</div>
+          {%- if block.settings.header != blank -%}
+            <div class="h1 rte">{{ block.settings.header }}</div>
           {%- endif -%}
 
           {% if cta_label != blank %}
@@ -448,10 +435,10 @@
       {%- endfor -%}
     {%- else -%}
       {%- comment -%} Optional placeholder cards when no blocks exist {%- endcomment -%}
-      {% for i in (1..2) %}
-        <article class="product-card" role="listitem">
+      {% for i in (1..3) %}
+        <article class="p6-item" role="listitem">
           <div class="img-frame" style="aspect-ratio: 9 / 14;"><div class="placeholder">9:14 image</div></div>
-          <div class="sub">Subhead</div>
+          <div class="h1">Header</div>
           <a class="btn" href="#" aria-label="CTA">CTA</a>
         </article>
       {% endfor %}
@@ -645,6 +632,7 @@
       "blocks": [
         { "type": "ingredient_card" },
         { "type": "ingredient_card" },
+        { "type": "content_group" },
         { "type": "content_group" },
         { "type": "content_group" }
       ]


### PR DESCRIPTION
## Summary
- Allow each Part 6 content block to choose its own image via schema settings
- Render content blocks instead of product blocks and show a third block by default

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9422f2efc832d97a303daa4a84c7a