### PR TITLE
feat: refresh part 6 product cards

### DIFF
--- a/Ad-Lander-2
+++ b/Ad-Lander-2
@@ -60,15 +60,6 @@
 
     #ad-lander-{{ section.id }} .rte [data-align] { display: block; width: 100%; }
 
-    #ad-lander-{{ section.id }} .btn {
-      display: inline-flex; align-items: center; justify-content: center;
-      padding: 10px 18px; border-radius: 999px; border: var(--wire-border);
-      background: white; color: #222; text-decoration: none; font-size: 14px;
-      transition: transform .2s ease, box-shadow .2s ease;
-    }
-    #ad-lander-{{ section.id }} .btn:hover { transform: translateY(-1px); box-shadow: 0 2px 10px rgba(0,0,0,.06); }
-    #ad-lander-{{ section.id }} .btn:focus-visible { outline: 2px solid #000; outline-offset: 2px; }
-
     /* Image frames with enforced aspect ratios */
     #ad-lander-{{ section.id }} .img-frame {
       position: relative; border-radius: var(--radius); overflow: hidden; border: var(--wire-border); background: var(--wire-gray-100);
@@ -170,18 +161,79 @@
     #ad-lander-{{ section.id }} .p5-prev { left: max(8px, calc((100vw - var(--container-w)) / 2 + 8px)); }
     #ad-lander-{{ section.id }} .p5-next { right: max(8px, calc((100vw - var(--container-w)) / 2 + 8px)); }
 
-    /* Part 6 (Image + header + CTA) */
-    #ad-lander-{{ section.id }} .p6 {
-      display: grid; gap: 28px; grid-template-columns: repeat(3, 1fr); text-align: center; padding-inline: var(--gutter);
+    /* =========================
+       PART 6: Product Cards (fresh)
+       ========================= */
+    #ad-lander-{{ section.id }} .p6 { padding-block: var(--space-y, 72px); }
+    #ad-lander-{{ section.id }} .p6-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 28px;
     }
-    #ad-lander-{{ section.id }} .p6-item {
-      display: grid; gap: 12px; justify-items: center;
+    @media (max-width: 1100px) {
+      #ad-lander-{{ section.id }} .p6-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
     }
-    #ad-lander-{{ section.id }} .p6-item .img-frame {
+    @media (max-width: 700px) {
+      #ad-lander-{{ section.id }} .p6-grid { grid-template-columns: 1fr; }
+    }
+
+    #ad-lander-{{ section.id }} .product-card {
+      border: var(--wire-border, 1px solid #e0e0e0);
+      border-radius: var(--radius, 16px);
+      background: #fff;
+      padding: 14px;
+      display: grid;
+      gap: 12px;
+      position: relative;
+    }
+
+    #ad-lander-{{ section.id }} .product-card:focus-within {
+      outline: 2px solid #000; outline-offset: 2px;
+    }
+
+    #ad-lander-{{ section.id }} .img-frame {
       aspect-ratio: 9 / 14;
-      width: 100%;
+      position: relative;
+      border-radius: var(--radius, 16px);
+      overflow: hidden;
+      border: var(--wire-border, 1px solid #e0e0e0);
+      background: #f5f5f5;
     }
-    #ad-lander-{{ section.id }} .p6 .img-frame { overflow: visible; }
+    #ad-lander-{{ section.id }} .img-frame img {
+      position: absolute; inset: 0;
+      width: 100%; height: 100%;
+      object-fit: cover;
+      transition: transform .25s ease;
+    }
+
+    #ad-lander-{{ section.id }} .copy {
+      display: grid;
+      gap: 10px;
+      transition: transform .25s ease, opacity .25s ease;
+    }
+    #ad-lander-{{ section.id }} .sub.rte { color: #5a5a5a; line-height: 1.5; }
+
+    #ad-lander-{{ section.id }} .btn {
+      display: inline-flex; align-items: center; justify-content: center;
+      padding: 10px 18px; border-radius: 999px;
+      border: var(--wire-border, 1px solid #e0e0e0);
+      background: white; color: #222; text-decoration: none; font-size: 14px;
+      transition: transform .2s ease, box-shadow .2s ease;
+    }
+    #ad-lander-{{ section.id }} .btn:hover { transform: translateY(-1px); box-shadow: 0 2px 10px rgba(0,0,0,.06); }
+    #ad-lander-{{ section.id }} .btn:focus-visible { outline: 2px solid #000; outline-offset: 2px; }
+
+    /* Hover / focus animation: image left, subhead right */
+    @media (prefers-reduced-motion: no-preference) {
+      #ad-lander-{{ section.id }} .product-card:hover .img-frame img,
+      #ad-lander-{{ section.id }} .product-card:focus-within .img-frame img {
+        transform: translateX(-12px);
+      }
+      #ad-lander-{{ section.id }} .product-card:hover .copy,
+      #ad-lander-{{ section.id }} .product-card:focus-within .copy {
+        transform: translateX(12px);
+      }
+    }
 
     /* Section-specific text colors */
     #ad-lander-{{ section.id }} .p1 .h1 { color: {{ section.settings.p1_header_color }}; }
@@ -200,7 +252,6 @@
     @media (max-width: 900px) {
       #ad-lander-{{ section.id }} .split { grid-template-columns: 1fr; }
       #ad-lander-{{ section.id }} .p4-grid { grid-template-columns: 1fr; }
-      #ad-lander-{{ section.id }} .p6 { grid-template-columns: 1fr; }
     }
   </style>
 
@@ -393,57 +444,78 @@
   {% endif %}
 
   <!-- =========================
-       PART 6: Content Blocks
-       Image, header + CTA via blocks
+       PART 6: Product Cards
        ========================= -->
   {% if section.settings.show_p6 %}
-  <div class="part p6" role="list" aria-label="Content items">
-    {%- assign content_blocks = section.blocks | where: 'type', 'content_group' -%}
-    {%- if content_blocks.size > 0 -%}
-      {%- for block in content_blocks -%}
-        {%- liquid
-          assign img = block.settings.image
-          assign alt_text = block.settings.alt | default: 'Content image'
-          assign cta_label = block.settings.cta_label
-          assign cta_url = block.settings.cta_url
-        -%}
-        <article class="p6-item" role="listitem" {{ block.shopify_attributes }}>
-          <div class="img-frame" style="aspect-ratio: 9 / 14; max-width: {{ block.settings.image_max_width }}px;">
-            {%- if img != blank -%}
-              {{ img | image_url: width: 1200 | image_tag:
-                loading: 'lazy',
-                alt: alt_text
-              }}
-            {%- else -%}
-              <div class="placeholder">9:14 image</div>
-            {%- endif -%}
-          </div>
+    <div class="part p6">
+      <div class="container">
+        <div class="p6-grid" role="list" aria-label="Product cards">
+          {%- assign product_blocks = section.blocks | where: 'type', 'product_card' -%}
+          {%- if product_blocks.size > 0 -%}
+            {%- for block in product_blocks -%}
+              {%- liquid
+                assign chosen_product = block.settings.product
+                assign manual_img = block.settings.image
+                assign final_img = manual_img
+                if final_img == blank and chosen_product and chosen_product.featured_image
+                  assign final_img = chosen_product.featured_image
+                endif
 
-          {%- if block.settings.header != blank -%}
-            <div class="h1 rte">{{ block.settings.header }}</div>
+                assign alt_text = block.settings.alt
+                if alt_text == blank and chosen_product
+                  assign alt_text = chosen_product.title
+                endif
+                if alt_text == blank
+                  assign alt_text = 'Product image'
+                endif
+
+                assign cta_label = block.settings.cta_label
+                assign cta_url = block.settings.cta_url
+                if cta_url == blank and chosen_product
+                  assign cta_url = chosen_product.url
+                endif
+              -%}
+              <article class="product-card" role="listitem" {{ block.shopify_attributes }}>
+                <div class="img-frame">
+                  {%- if final_img != blank -%}
+                    {{ final_img | image_url: width: 1200 | image_tag:
+                      loading: 'lazy',
+                      alt: alt_text
+                    }}
+                  {%- else -%}
+                    <div class="placeholder" aria-hidden="true" style="display:grid;place-items:center;color:#9a9a9a;font-size:12px;width:100%;height:100%;">9:14 image</div>
+                  {%- endif -%}
+                </div>
+
+                <div class="copy">
+                  {%- if block.settings.subhead != blank -%}
+                    <div class="sub rte">{{ block.settings.subhead }}</div>
+                  {%- endif -%}
+                </div>
+
+                {%- if cta_label != blank -%}
+                  <a class="btn"
+                     href="{{ cta_url }}"
+                     {% if block.settings.cta_newtab %}target="_blank" rel="noopener noreferrer"{% endif %}
+                     aria-label="{{ cta_label | strip }}">
+                    {{ cta_label }}
+                  </a>
+                {%- endif -%}
+              </article>
+            {%- endfor -%}
+          {%- else -%}
+            {%- comment -%} Placeholder cards when no blocks exist {%- endcomment -%}
+            {% for i in (1..2) %}
+              <article class="product-card" role="listitem">
+                <div class="img-frame"><div class="placeholder" aria-hidden="true" style="display:grid;place-items:center;color:#9a9a9a;font-size:12px;width:100%;height:100%;">9:14 image</div></div>
+                <div class="copy"><div class="sub">Subhead</div></div>
+                <a class="btn" href="#" aria-label="CTA">CTA</a>
+              </article>
+            {% endfor %}
           {%- endif -%}
-
-          {% if cta_label != blank %}
-            <a class="btn"
-               href="{{ cta_url }}"
-               {% if block.settings.cta_newtab %}target="_blank" rel="noopener noreferrer"{% endif %}
-               aria-label="{{ cta_label | strip }}">
-              {{ cta_label }}
-            </a>
-          {% endif %}
-        </article>
-      {%- endfor -%}
-    {%- else -%}
-      {%- comment -%} Optional placeholder cards when no blocks exist {%- endcomment -%}
-      {% for i in (1..3) %}
-        <article class="p6-item" role="listitem">
-          <div class="img-frame" style="aspect-ratio: 9 / 14;"><div class="placeholder">9:14 image</div></div>
-          <div class="h1">Header</div>
-          <a class="btn" href="#" aria-label="CTA">CTA</a>
-        </article>
-      {% endfor %}
-    {%- endif -%}
-  </div>
+        </div>
+      </div>
+    </div>
   {% endif %}
 </section>
 
@@ -552,7 +624,7 @@
     { "type": "checkbox", "id": "show_p3", "label": "Show Part 3 (Showcase)", "default": true },
     { "type": "checkbox", "id": "show_p4", "label": "Show Part 4 (Intro+CTA)", "default": true },
     { "type": "checkbox", "id": "show_p5", "label": "Show Part 5 (Ingredients)", "default": true },
-    { "type": "checkbox", "id": "show_p6", "label": "Show Part 6 (Content group)", "default": true },
+    { "type": "checkbox", "id": "show_p6", "label": "Show Part 6 (Products)", "default": true },
 
     { "type": "header", "content": "Part 1 — Intro" },
     { "type": "richtext", "id": "p1_header", "label": "Header" },
@@ -599,7 +671,7 @@
     { "type": "richtext", "id": "p5_header", "label": "Header" },
     { "type": "color", "id": "p5_header_color", "label": "Header color", "default": "#5a5a5a" },
     { "type": "color", "id": "p5_subhead_color", "label": "Card subhead color", "default": "#9a9a9a" },
-    { "type": "header", "content": "Part 6 — Content group" },
+    { "type": "header", "content": "Part 6 — Products" },
     { "type": "color", "id": "p6_header_color", "label": "Header color", "default": "#5a5a5a" }
   ],
   "blocks": [
@@ -613,18 +685,18 @@
       ]
     },
     {
-        "type": "content_group",
-        "name": "Content group",
-        "settings": [
-          { "type": "image_picker", "id": "image", "label": "Image (9:14)" },
-          { "type": "range", "id": "image_max_width", "label": "Image max width (px)", "min": 50, "max": 600, "step": 10, "default": 250 },
-          { "type": "text", "id": "alt", "label": "Image alt text" },
-          { "type": "richtext", "id": "header", "label": "Header" },
-          { "type": "text", "id": "cta_label", "label": "CTA label" },
-          { "type": "url", "id": "cta_url", "label": "CTA link" },
-          { "type": "checkbox", "id": "cta_newtab", "label": "Open CTA in new tab", "default": false }
-        ]
-      }
+      "type": "product_card",
+      "name": "Product Card",
+      "settings": [
+        { "type": "product", "id": "product", "label": "Product (optional)" },
+        { "type": "image_picker", "id": "image", "label": "Image override (9:14)" },
+        { "type": "text", "id": "alt", "label": "Image alt text" },
+        { "type": "richtext", "id": "subhead", "label": "Subhead" },
+        { "type": "text", "id": "cta_label", "label": "CTA label" },
+        { "type": "url", "id": "cta_url", "label": "CTA link (overrides product URL if set)" },
+        { "type": "checkbox", "id": "cta_newtab", "label": "Open CTA in new tab", "default": false }
+      ]
+    }
     ],
     "presets": [
       {
@@ -632,9 +704,9 @@
       "blocks": [
         { "type": "ingredient_card" },
         { "type": "ingredient_card" },
-        { "type": "content_group" },
-        { "type": "content_group" },
-        { "type": "content_group" }
+        { "type": "product_card" },
+        { "type": "product_card" },
+        { "type": "product_card" }
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- replace Part 6 markup and styling with responsive product card grid
- add product_card block with rich text subhead and CTA options
- tweak schema toggle labeling for new product card section

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b944673188832d9ab2ce1ad5c08551