### PR TITLE
Fix ingredient card toggle layout

### DIFF
--- a/Ad-Lander-2
+++ b/Ad-Lander-2
@@ -149,7 +149,7 @@
       scroll-snap-align: start; border: var(--wire-border); border-radius: var(--radius);
       background: rgba(255,255,255,0.9); backdrop-filter: saturate(120%) blur(2px);
       display: grid; gap: 10px; width: min(280px, 75vw); padding: 12px;
-      position: relative; grid-template-columns: 1fr; transition: width .3s ease;
+      position: relative; grid-template-columns: min(280px, 75vw); transition: width .3s ease;
     }
     #ad-lander-{{ section.id }} .card .img-frame { aspect-ratio: 2 / 3; }
     #ad-lander-{{ section.id }} .card .menu-btn {
@@ -159,10 +159,10 @@
     }
     #ad-lander-{{ section.id }} .card .description { display: none; }
     #ad-lander-{{ section.id }} .card.expanded {
-      grid-template-columns: 1fr 1fr; width: min(500px, 90vw);
+      grid-template-columns: min(280px, 75vw) 1fr; width: min(500px, 90vw);
     }
     #ad-lander-{{ section.id }} .card.expanded .description { display: block; }
-    #ad-lander-{{ section.id }} .card .main { display: grid; gap: 10px; }
+    #ad-lander-{{ section.id }} .card .main { display: grid; gap: 10px; width: min(280px, 75vw); }
     #ad-lander-{{ section.id }} .p5-arrow {
       position: absolute; top: 50%; transform: translateY(-50%);
       width: 40px; height: 40px; border-radius: 999px; border: var(--wire-border); background: #fff;


### PR DESCRIPTION
## Summary
- prevent ingredient card images from resizing when hamburger menu is toggled
- keep card width transition while locking image column width

## Testing
- `npm test` *(fails: ENOENT no such file or directory, package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b957682140832d81fc37c7d34505c7