### PR TITLE
Reduce Part 2 header-subhead gap

### DIFF
--- a/Ad-Lander-2
+++ b/Ad-Lander-2
@@ -24,7 +24,7 @@
     assign g  = section.settings.gutter | default: 24
     assign r  = section.settings.corner_radius | default: 16
     assign space = section.settings.section_space | default: 72
-    assign p2_gap = section.settings.p2_gap | default: 4
+    assign p2_gap = section.settings.p2_gap | default: 2
     -%}
 
   <style>


### PR DESCRIPTION
## Summary
- tighten spacing between Part 2 header and subhead by lowering default gap variable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b95c9e92ec832d994a3dbfde53bb14