### PR TITLE
Tighten Part-2 header-subhead spacing

### DIFF
--- a/Ad-Lander-2
+++ b/Ad-Lander-2
@@ -105,7 +105,8 @@
     #ad-lander-{{ section.id }} .p2-inner {
       position: relative; z-index: 1;
       padding: clamp(28px, 6vw, 64px);
-      display: grid; gap: var(--p2-gap); text-align: center;
+      /* Reduce the gap between the header and subhead */
+      display: grid; gap: calc(var(--p2-gap) / 2); text-align: center;
       justify-items: center;
     }
 


### PR DESCRIPTION
## Summary
- Reduce vertical spacing between Part-2 header and subhead by halving the grid gap

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b95e0dcabc832daf312ecde855a053