### PR TITLE
Add height control for ingredients section

### DIFF
--- a/Ad-Lander-2
+++ b/Ad-Lander-2
@@ -35,6 +35,7 @@
       --space-y: {{ space }}px;
       --p2-height: {{ section.settings.p2_height | default: 400 }}px;
       --p2-gap: {{ p2_gap }}px;
+      --p5-height: {{ section.settings.p5_height | default: 400 }}px;
       --product-image-width: {{ section.settings.product_image_width | default: 300 }}px;
       --product-image-width-mobile: {{ section.settings.product_image_width_mobile | default: 220 }}px;
       --wire-gray-100: #f5f5f5;
@@ -125,9 +126,10 @@
     #ad-lander-{{ section.id }} .p4-right { display: grid; gap: 16px; justify-items: start; }
 
     /* Part 5 (Ingredient Cards, FULL BLEED background, horizontal scroll) */
-    #ad-lander-{{ section.id }} .p5 {
-      position: relative; padding-block: calc(var(--space-y) * 1.25);
-    }
+      #ad-lander-{{ section.id }} .p5 {
+        position: relative; padding-block: calc(var(--space-y) * 1.25);
+        min-height: var(--p5-height);
+      }
     #ad-lander-{{ section.id }} .p5 .bg {
       position: absolute; inset: 0; background-size: cover; background-position: center;
     }
@@ -777,10 +779,11 @@
     { "type": "header", "content": "Part 5 — Ingredients" },
     { "type": "image_picker", "id": "p5_bg", "label": "Full-bleed background" },
     { "type": "color", "id": "p5_overlay", "label": "Overlay color", "default": "#000000" },
-    { "type": "range", "id": "p5_overlay_opacity", "label": "Overlay opacity (%)", "min": 0, "max": 95, "step": 5, "default": 0 },
-    { "type": "richtext", "id": "p5_header", "label": "Header" },
-    { "type": "color", "id": "p5_header_color", "label": "Header color", "default": "#5a5a5a" },
-    { "type": "color", "id": "p5_subhead_color", "label": "Card subhead color", "default": "#9a9a9a" },
+      { "type": "range", "id": "p5_overlay_opacity", "label": "Overlay opacity (%)", "min": 0, "max": 95, "step": 5, "default": 0 },
+      { "type": "range", "id": "p5_height", "label": "Section min height (px)", "min": 200, "max": 800, "step": 20, "default": 400 },
+      { "type": "richtext", "id": "p5_header", "label": "Header" },
+      { "type": "color", "id": "p5_header_color", "label": "Header color", "default": "#5a5a5a" },
+      { "type": "color", "id": "p5_subhead_color", "label": "Card subhead color", "default": "#9a9a9a" },
     { "type": "header", "content": "Product showcase" },
     { "type": "range", "id": "product_image_width", "label": "Product image width (px)", "min": 100, "max": 600, "step": 10, "default": 300 },
     { "type": "range", "id": "product_image_width_mobile", "label": "Product image width - mobile (px)", "min": 100, "max": 400, "step": 10, "default": 220 },


### PR DESCRIPTION
## Summary
- add `p5_height` setting for ingredient section
- apply `--p5-height` CSS variable for Part 5 min height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b96536d090832d9b4996d419525760