### PR TITLE
fix: prevent Part 5 background image clipping

### DIFF
--- a/Ad-Lander-2
+++ b/Ad-Lander-2
@@ -131,7 +131,7 @@
         min-height: var(--p5-height);
       }
     #ad-lander-{{ section.id }} .p5 .bg {
-      position: absolute; inset: 0; background-size: cover; background-position: center;
+      position: absolute; inset: 0; background-size: contain; background-position: center; background-repeat: no-repeat;
     }
     #ad-lander-{{ section.id }} .p5 .overlay {
       position: absolute; inset: 0; pointer-events: none;


### PR DESCRIPTION
## Summary
- avoid clipping of Part 5 background image by using `background-size: contain` and disabling repeat

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9667421a8832dbd98697de2a84ba4