### PR TITLE
feat: allow taller Part 5 background

### DIFF
--- a/Ad-Lander-2
+++ b/Ad-Lander-2
@@ -784,7 +784,7 @@
     { "type": "image_picker", "id": "p5_bg", "label": "Full-bleed background" },
     { "type": "color", "id": "p5_overlay", "label": "Overlay color", "default": "#000000" },
       { "type": "range", "id": "p5_overlay_opacity", "label": "Overlay opacity (%)", "min": 0, "max": 95, "step": 5, "default": 0 },
-      { "type": "range", "id": "p5_height", "label": "Section min height (px)", "min": 200, "max": 800, "step": 20, "default": 400 },
+      { "type": "range", "id": "p5_height", "label": "Section min height (px)", "min": 200, "max": 1600, "step": 20, "default": 400 },
       { "type": "richtext", "id": "p5_header", "label": "Header" },
       { "type": "color", "id": "p5_header_color", "label": "Header color", "default": "#5a5a5a" },
       { "type": "color", "id": "p5_subhead_color", "label": "Card subhead color", "default": "#9a9a9a" },


### PR DESCRIPTION
## Summary
- allow Part 5's background section to grow up to 1600px so larger images can display fully

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b968b9201c832db444359cdaba78b3