### PR TITLE
fix: make part 5 background full bleed

### DIFF
--- a/Ad-Lander-2
+++ b/Ad-Lander-2
@@ -131,7 +131,7 @@
         min-height: var(--p5-height);
       }
     #ad-lander-{{ section.id }} .p5 .bg {
-      position: absolute; inset: 0; background-size: contain; background-position: center; background-repeat: no-repeat;
+      position: absolute; inset: 0; background-size: cover; background-position: center; background-repeat: no-repeat;
     }
     #ad-lander-{{ section.id }} .p5 .overlay {
       position: absolute; inset: 0; pointer-events: none;


### PR DESCRIPTION
## Summary
- make Part 5 background cover entire section for full-bleed appearance

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Ad-Lander-2/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b96bf2d198832d87375852e7830c64