### PR TITLE
fix: contain ingredient card images

### DIFF
--- a/Ad-Lander-2
+++ b/Ad-Lander-2
@@ -174,6 +174,7 @@
       background: rgba(255,255,255,0.9); backdrop-filter: saturate(120%) blur(2px);
       display: grid; gap: 10px; width: min(var(--p5-card-width), 75vw); padding: 12px;
       position: relative; grid-template-columns: min(var(--p5-card-width), 75vw); transition: width .3s ease;
+      overflow: hidden;
     }
     #ad-lander-{{ section.id }} .card .img-frame { aspect-ratio: 2 / 3; }
     #ad-lander-{{ section.id }} .card .menu-btn {


### PR DESCRIPTION
## Summary
- contain images within ingredient cards so they no longer overlap the card's background

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f49c2100832db0a17ad322fd14c2